### PR TITLE
Add current version provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = ">= 1.60.2, <= 1.70.9"
     }
   }
   required_version = ">= v1.0.11"


### PR DESCRIPTION
### What does this PR do?
Expands version constraint for Lightstep providers utilized in various modules.

### Why?
We need to support multiple Lightstep provider versions, because certain modules utilize types which aren't available in other versions. Specifically, current modules use the "lightstep_metric_dashboard" type which is unsupported in v1.70.9 and the type exported from the app is "lightstep_dashboard" which is unsupported in v1.60.2. It's important that we be able to add modules using the latest provider, because (a) we should stay current with provider development, (b) staying current with the provider is the only way we can validate code with the API, and (c) more recent provider versions enable representation of the average statistic in the way described by CloudWatch docs and the average statistic features prominently in other AWS dashboards.
