### PR TITLE
Fix ELB metric names (LS-38357)

### DIFF
--- a/modules/applicationelb-dashboard/main.tf
+++ b/modules/applicationelb-dashboard/main.tf
@@ -22,7 +22,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "bar"
       hidden     = false
 
-      metric              = "aws.elb.request_count_count"
+      metric              = "aws.applicationelb.request_count_count"
       timeseries_operator = "delta"
 
 
@@ -45,7 +45,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "line"
       hidden     = false
 
-      metric              = "aws.elb.http_code_elb_5xx_count_count"
+      metric              = "aws.applicationelb.http_code_elb_5xx_count_count"
       timeseries_operator = "rate"
 
 
@@ -61,7 +61,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "line"
       hidden     = false
 
-      metric              = "aws.elb.http_code_elb_4xx_count_count"
+      metric              = "aws.applicationelb.http_code_elb_4xx_count_count"
       timeseries_operator = "rate"
 
 
@@ -84,7 +84,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "bar"
       hidden     = false
 
-      metric              = "aws.elb.active_connection_count_count"
+      metric              = "aws.applicationelb.active_connection_count_count"
       timeseries_operator = "delta"
 
       group_by {
@@ -99,7 +99,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "bar"
       hidden     = false
 
-      metric              = "aws.elb.new_connection_count_count"
+      metric              = "aws.applicationelb.new_connection_count_count"
       timeseries_operator = "delta"
 
 
@@ -122,7 +122,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "line"
       hidden     = false
 
-      metric              = "aws.elb.consumed_lcus_max"
+      metric              = "aws.applicationelb.consumed_lcus_max"
       timeseries_operator = "last"
 
 
@@ -138,7 +138,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "line"
       hidden     = false
 
-      metric              = "aws.elb.processed_bytes_max"
+      metric              = "aws.applicationelb.processed_bytes_max"
       timeseries_operator = "last"
 
 

--- a/modules/applicationelb-dashboard/main.tf
+++ b/modules/applicationelb-dashboard/main.tf
@@ -22,7 +22,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "bar"
       hidden     = false
 
-      metric              = "aws.application_elb.request_count_count"
+      metric              = "aws.elb.request_count_count"
       timeseries_operator = "delta"
 
 
@@ -45,7 +45,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "line"
       hidden     = false
 
-      metric              = "aws.application_elb.http_code_elb_5xx_count_count"
+      metric              = "aws.elb.http_code_elb_5xx_count_count"
       timeseries_operator = "rate"
 
 
@@ -61,7 +61,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "line"
       hidden     = false
 
-      metric              = "aws.application_elb.http_code_elb_4xx_count_count"
+      metric              = "aws.elb.http_code_elb_4xx_count_count"
       timeseries_operator = "rate"
 
 
@@ -84,7 +84,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "bar"
       hidden     = false
 
-      metric              = "aws.application_elb.active_connection_count_count"
+      metric              = "aws.elb.active_connection_count_count"
       timeseries_operator = "delta"
 
       group_by {
@@ -99,7 +99,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "bar"
       hidden     = false
 
-      metric              = "aws.application_elb.new_connection_count_count"
+      metric              = "aws.elb.new_connection_count_count"
       timeseries_operator = "delta"
 
 
@@ -122,7 +122,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "line"
       hidden     = false
 
-      metric              = "aws.application_elb.consumed_lcus_max"
+      metric              = "aws.elb.consumed_lcus_max"
       timeseries_operator = "last"
 
 
@@ -138,7 +138,7 @@ resource "lightstep_metric_dashboard" "aws_app_elb_dashboard" {
       display    = "line"
       hidden     = false
 
-      metric              = "aws.application_elb.processed_bytes_max"
+      metric              = "aws.elb.processed_bytes_max"
       timeseries_operator = "last"
 
 

--- a/modules/chatbot-dashboard/main.tf
+++ b/modules/chatbot-dashboard/main.tf
@@ -27,7 +27,7 @@ resource "lightstep_metric_dashboard" "aws_chatbot_dashboard" {
 
 
       group_by {
-        aggregation_method = "delta"
+        aggregation_method = "sum"
         keys               = []
       }
 


### PR DESCRIPTION
Metric names that we get from AWS use namespace .elb. and not .application_elb.
See https://lightstep.atlassian.net/browse/LS-38357