### PR TITLE
Bump to provider ~> 1.70.10

### DIFF
--- a/examples/applicationelb-dashboard/main.tf
+++ b/examples/applicationelb-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/examples/ec2-dashboard/main.tf
+++ b/examples/ec2-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/examples/rds-dashboard/main.tf
+++ b/examples/rds-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = ">= 1.60.2, <= 1.70.9"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/amplify-dashboard/main.tf
+++ b/modules/amplify-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/apigateway-dashboard/main.tf
+++ b/modules/apigateway-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/applicationelb-dashboard/main.tf
+++ b/modules/applicationelb-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/autoscaling-dashboard/main.tf
+++ b/modules/autoscaling-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.70.9"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/backup-dashboard/main.tf
+++ b/modules/backup-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/chatbot-dashboard/main.tf
+++ b/modules/chatbot-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/chime-dashboard/main.tf
+++ b/modules/chime-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/cloudfront-dashboard/main.tf
+++ b/modules/cloudfront-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/cloudhsm-dashboard/main.tf
+++ b/modules/cloudhsm-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/cloudtrail-dashboard/main.tf
+++ b/modules/cloudtrail-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/cognito-dashboard/main.tf
+++ b/modules/cognito-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/dynamodb-dashboard/main.tf
+++ b/modules/dynamodb-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/ebs-dashboard/main.tf
+++ b/modules/ebs-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.70.9"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/ec2-dashboard/main.tf
+++ b/modules/ec2-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/ecs-dashboard/main.tf
+++ b/modules/ecs-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/efs-dashboard/main.tf
+++ b/modules/efs-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/elasticache-redis-dashboard/main.tf
+++ b/modules/elasticache-redis-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/eventbridge-dashboard/main.tf
+++ b/modules/eventbridge-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.70.9"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/inspector-dashboard/main.tf
+++ b/modules/inspector-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/kinesis-dashboard/main.tf
+++ b/modules/kinesis-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/lambda-dashboard/main.tf
+++ b/modules/lambda-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/natgateway-dashboard/main.tf
+++ b/modules/natgateway-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/rds-dashboard/main.tf
+++ b/modules/rds-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/route53-dashboard/main.tf
+++ b/modules/route53-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/s3-dashboard/main.tf
+++ b/modules/s3-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/sns-dashboard/main.tf
+++ b/modules/sns-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"

--- a/modules/sqs-dashboard/main.tf
+++ b/modules/sqs-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"


### PR DESCRIPTION
Changing based on discussion with Greg Dalavalle and Clay.

Because...
- We need features released in 1.70.10 (Greg)
- Pinning to multiple providers in the submodules breaks the main module (Clay)
