### PR TITLE
Remove aws_region var from EC2 dashboard

### DIFF
--- a/modules/ec2-dashboard/main.tf
+++ b/modules/ec2-dashboard/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 resource "lightstep_metric_dashboard" "aws_ec2_dashboard" {
   project_name   = var.lightstep_project
-  dashboard_name = "AWS EC2 (${var.aws_region})"
+  dashboard_name = "AWS EC2"
 
   chart {
     name = "CPU Utilization"

--- a/modules/ec2-dashboard/variables.tf
+++ b/modules/ec2-dashboard/variables.tf
@@ -2,8 +2,3 @@ variable "lightstep_project" {
   description = "Name of Lightstep project"
   type        = string
 }
-
-variable "aws_region" {
-  description = "AWS Region Name"
-  type        = string
-}


### PR DESCRIPTION
We were only using the variable to style the chart title.