### PR TITLE
Reformat prebuilt dashboards

### DIFF
--- a/modules/amplify-dashboard/main.tf
+++ b/modules/amplify-dashboard/main.tf
@@ -11,7 +11,7 @@ terraform {
 resource "lightstep_dashboard" "aws_amplify_dashboard" {
   project_name          = var.lightstep_project
   dashboard_name        = "AWS Amplify"
-  dashboard_description = ""
+  dashboard_description = "Monitor AWS Amplify with this summary dashboard."
 
   chart {
     name = "Requests Count"

--- a/modules/amplify-dashboard/main.tf
+++ b/modules/amplify-dashboard/main.tf
@@ -8,9 +8,10 @@ terraform {
   required_version = ">= v1.0.11"
 }
 
-resource "lightstep_metric_dashboard" "aws_amplify_dashboard" {
-  project_name   = var.lightstep_project
-  dashboard_name = "AWS Amplify"
+resource "lightstep_dashboard" "aws_amplify_dashboard" {
+  project_name          = var.lightstep_project
+  dashboard_name        = "AWS Amplify"
+  dashboard_description = ""
 
   chart {
     name = "Requests Count"
@@ -18,19 +19,10 @@ resource "lightstep_metric_dashboard" "aws_amplify_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.amplify.requests_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.amplify.requests_sum | delta | group_by [], sum"
     }
 
   }
@@ -41,35 +33,17 @@ resource "lightstep_metric_dashboard" "aws_amplify_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.amplify.bytes_downloaded_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.amplify.bytes_downloaded_sum | delta | group_by [], sum"
     }
 
     query {
-      query_name = "b"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.amplify.bytes_uploaded_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "b"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.amplify.bytes_uploaded_sum | delta | group_by [], sum"
     }
 
   }
@@ -80,35 +54,17 @@ resource "lightstep_metric_dashboard" "aws_amplify_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.amplify.4xx_errors_rate_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.amplify.4xx_errors_rate_sum | delta | group_by [], sum"
     }
 
     query {
-      query_name = "b"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.amplify.5xx_errors_rate_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "b"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.amplify.5xx_errors_rate_sum | delta | group_by [], sum"
     }
 
   }
@@ -119,19 +75,10 @@ resource "lightstep_metric_dashboard" "aws_amplify_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.amplify.latency_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.amplify.latency_max | latest | group_by [], sum"
     }
 
   }

--- a/modules/elasticache-redis-dashboard/main.tf
+++ b/modules/elasticache-redis-dashboard/main.tf
@@ -8,9 +8,10 @@ terraform {
   required_version = ">= v1.0.11"
 }
 
-resource "lightstep_metric_dashboard" "aws_elasticache_redis_dashboard" {
-  project_name   = var.lightstep_project
-  dashboard_name = "AWS ElastiCache (Redis)"
+resource "lightstep_dashboard" "aws_elasticache_redis_dashboard" {
+  project_name          = var.lightstep_project
+  dashboard_name        = "AWS ElastiCache (Redis)"
+  dashboard_description = ""
 
   chart {
     name = "Cache"
@@ -18,35 +19,21 @@ resource "lightstep_metric_dashboard" "aws_elasticache_redis_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.elasti_cache.cache_hits_count"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["CacheClusterId", ]
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.elasti_cache.cache_hits_count | delta | group_by ["CacheClusterId"], sum
+EOT
     }
 
     query {
-      query_name = "b"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.elasti_cache.cache_misses_count"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["CacheClusterId", ]
-      }
-
+      query_name   = "b"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.elasti_cache.cache_misses_count | delta | group_by ["CacheClusterId"], sum
+EOT
     }
 
   }
@@ -57,35 +44,17 @@ resource "lightstep_metric_dashboard" "aws_elasticache_redis_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.elasti_cache.curr_connections_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.elasti_cache.curr_connections_max | latest | group_by [], sum"
     }
 
     query {
-      query_name = "b"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.elasti_cache.new_connections_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "b"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.elasti_cache.new_connections_max | latest | group_by [], sum"
     }
 
   }
@@ -96,35 +65,21 @@ resource "lightstep_metric_dashboard" "aws_elasticache_redis_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.elasti_cache.save_in_progress_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["CacheClusterId", ]
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.elasti_cache.save_in_progress_max | latest | group_by ["CacheClusterId"], sum
+EOT
     }
 
     query {
-      query_name = "b"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.elasti_cache.curr_items_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["CacheClusterId", ]
-      }
-
+      query_name   = "b"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.elasti_cache.curr_items_max | latest | group_by ["CacheClusterId"], sum
+EOT
     }
 
   }
@@ -135,35 +90,21 @@ resource "lightstep_metric_dashboard" "aws_elasticache_redis_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.elasti_cache.bytes_used_for_cache_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["CacheClusterId", ]
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.elasti_cache.bytes_used_for_cache_max | latest | group_by ["CacheClusterId"], sum
+EOT
     }
 
     query {
-      query_name = "b"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.elasti_cache.replication_bytes_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["CacheClusterId", ]
-      }
-
+      query_name   = "b"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.elasti_cache.replication_bytes_max | latest | group_by ["CacheClusterId"], sum
+EOT
     }
 
   }
@@ -174,19 +115,12 @@ resource "lightstep_metric_dashboard" "aws_elasticache_redis_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.elasti_cache.replication_lag_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["CacheClusterId", ]
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.elasti_cache.replication_lag_max | latest | group_by ["CacheClusterId"], sum
+EOT
     }
 
   }
@@ -197,19 +131,10 @@ resource "lightstep_metric_dashboard" "aws_elasticache_redis_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.elasti_cache.database_memory_usage_percentage_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = "metric aws.elasti_cache.database_memory_usage_percentage_max | latest | group_by [], sum"
     }
 
   }
@@ -220,19 +145,12 @@ resource "lightstep_metric_dashboard" "aws_elasticache_redis_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.elasti_cache.cpu_utilization_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["CacheClusterId", ]
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.elasti_cache.cpu_utilization_max | latest | group_by ["CacheClusterId"], sum
+EOT
     }
 
   }
@@ -243,35 +161,21 @@ resource "lightstep_metric_dashboard" "aws_elasticache_redis_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.elasti_cache.network_bytes_in_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["CacheClusterId", ]
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.elasti_cache.network_bytes_in_max | latest | group_by ["CacheClusterId"], sum
+EOT
     }
 
     query {
-      query_name = "b"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.elasti_cache.network_bytes_out_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["CacheClusterId", ]
-      }
-
+      query_name   = "b"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.elasti_cache.network_bytes_out_max | latest | group_by ["CacheClusterId"], sum
+EOT
     }
 
   }

--- a/modules/elasticache-redis-dashboard/main.tf
+++ b/modules/elasticache-redis-dashboard/main.tf
@@ -11,7 +11,7 @@ terraform {
 resource "lightstep_dashboard" "aws_elasticache_redis_dashboard" {
   project_name          = var.lightstep_project
   dashboard_name        = "AWS ElastiCache (Redis)"
-  dashboard_description = ""
+  dashboard_description = "Monitor AWS ElastiCache (Redis) with this overview dashboard."
 
   chart {
     name = "Cache"

--- a/modules/lambda-dashboard/main.tf
+++ b/modules/lambda-dashboard/main.tf
@@ -8,9 +8,10 @@ terraform {
   required_version = ">= v1.0.11"
 }
 
-resource "lightstep_metric_dashboard" "aws_lambda_dashboard" {
-  project_name   = var.lightstep_project
-  dashboard_name = "AWS Lambda"
+resource "lightstep_dashboard" "aws_lambda_dashboard" {
+  project_name          = var.lightstep_project
+  dashboard_name        = "AWS Lambda"
+  dashboard_description = ""
 
   chart {
     name = "Duration"
@@ -18,18 +19,12 @@ resource "lightstep_metric_dashboard" "aws_lambda_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.lambda.duration_max"
-      timeseries_operator = "last"
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.lambda.duration_max | latest | group_by [], sum
+EOT
     }
 
   }
@@ -40,18 +35,12 @@ resource "lightstep_metric_dashboard" "aws_lambda_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "b"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.lambda.invocations_count"
-      timeseries_operator = "delta"
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.lambda.invocations_count | delta | group_by [], sum
+EOT
     }
 
   }
@@ -62,18 +51,12 @@ resource "lightstep_metric_dashboard" "aws_lambda_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.lambda.errors_max"
-      timeseries_operator = "last"
-
-      group_by {
-        aggregation_method = "avg"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.lambda.errors_max | latest | group_by [], mean
+EOT
     }
 
   }
@@ -84,18 +67,12 @@ resource "lightstep_metric_dashboard" "aws_lambda_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.lambda.throttles_max"
-      timeseries_operator = "last"
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.lambda.throttles_max | latest | group_by [], sum
+EOT
     }
 
   }
@@ -106,33 +83,21 @@ resource "lightstep_metric_dashboard" "aws_lambda_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.lambda.concurrent_executions_count"
-      timeseries_operator = "delta"
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.lambda.concurrent_executions_count | delta | group_by [], sum
+EOT
     }
 
     query {
-      query_name = "b"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.lambda.unreserved_concurrent_executions_count"
-      timeseries_operator = "delta"
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "b"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.lambda.unreserved_concurrent_executions_count | delta | group_by [], sum
+EOT
     }
 
   }

--- a/modules/lambda-dashboard/main.tf
+++ b/modules/lambda-dashboard/main.tf
@@ -11,7 +11,7 @@ terraform {
 resource "lightstep_dashboard" "aws_lambda_dashboard" {
   project_name          = var.lightstep_project
   dashboard_name        = "AWS Lambda"
-  dashboard_description = ""
+  dashboard_description = "Monitor AWS Lambda with this summary dashboard."
 
   chart {
     name = "Duration"

--- a/modules/natgateway-dashboard/main.tf
+++ b/modules/natgateway-dashboard/main.tf
@@ -12,7 +12,7 @@ terraform {
 resource "lightstep_dashboard" "aws_natgateway_dashboard" {
   project_name   = var.lightstep_project
   dashboard_name = "AWS NAT Gateway"
-  description = "Monitor AWS NAT Gateway with this summary dashboard."
+  dashboard_description = "Monitor AWS NAT Gateway with this summary dashboard."
 
   chart {
     name = "Bytes In From Destination"

--- a/modules/natgateway-dashboard/main.tf
+++ b/modules/natgateway-dashboard/main.tf
@@ -10,8 +10,8 @@ terraform {
 
 
 resource "lightstep_dashboard" "aws_natgateway_dashboard" {
-  project_name   = var.lightstep_project
-  dashboard_name = "AWS NAT Gateway"
+  project_name          = var.lightstep_project
+  dashboard_name        = "AWS NAT Gateway"
   dashboard_description = "Monitor AWS NAT Gateway with this summary dashboard."
 
   chart {

--- a/modules/route53-dashboard/main.tf
+++ b/modules/route53-dashboard/main.tf
@@ -11,7 +11,7 @@ terraform {
 resource "lightstep_dashboard" "aws_route53_dashboard" {
   project_name          = var.lightstep_project
   dashboard_name        = "AWS Route53"
-  dashboard_description = ""
+  dashboard_description = "Monitor AWS Route53 with this summary dashboard."
 
   chart {
     name = "Health Check Percentage Healthy"

--- a/modules/route53-dashboard/main.tf
+++ b/modules/route53-dashboard/main.tf
@@ -8,9 +8,10 @@ terraform {
   required_version = ">= v1.0.11"
 }
 
-resource "lightstep_metric_dashboard" "aws_route53_dashboard" {
-  project_name   = var.lightstep_project
-  dashboard_name = "AWS Route53"
+resource "lightstep_dashboard" "aws_route53_dashboard" {
+  project_name          = var.lightstep_project
+  dashboard_name        = "AWS Route53"
+  dashboard_description = ""
 
   chart {
     name = "Health Check Percentage Healthy"
@@ -18,35 +19,17 @@ resource "lightstep_metric_dashboard" "aws_route53_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "g"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.route53.health_check_percentage_healthy_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.route53.health_check_percentage_healthy_sum | delta | group_by [], sum"
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.route53.child_health_check_healthy_count_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "b"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.route53.child_health_check_healthy_count_sum | delta | group_by [], sum"
     }
 
   }
@@ -57,35 +40,17 @@ resource "lightstep_metric_dashboard" "aws_route53_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "g"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.route53.connection_time_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.route53.connection_time_sum | delta | group_by [], sum"
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.route53.time_to_first_byte_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "b"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.route53.time_to_first_byte_sum | delta | group_by [], sum"
     }
 
   }
@@ -96,19 +61,10 @@ resource "lightstep_metric_dashboard" "aws_route53_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "g"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.route53.health_check_status_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.route53.health_check_status_sum | delta | group_by [], sum"
     }
 
   }
@@ -119,19 +75,10 @@ resource "lightstep_metric_dashboard" "aws_route53_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "g"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.route53.ssl_handshake_time_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = "metric aws.route53.ssl_handshake_time_sum | delta | group_by [], sum"
     }
 
   }

--- a/modules/s3-dashboard/main.tf
+++ b/modules/s3-dashboard/main.tf
@@ -11,7 +11,7 @@ terraform {
 resource "lightstep_dashboard" "aws_s3_dashboard" {
   project_name          = var.lightstep_project
   dashboard_name        = "AWS S3"
-  dashboard_description = "Monitor AWS S3 to understand and improve the processes storage data performance."
+  dashboard_description = "Monitor AWS S3 performance with this overview dashboard."
 
   chart {
     name = "Requests"

--- a/modules/s3-dashboard/main.tf
+++ b/modules/s3-dashboard/main.tf
@@ -24,6 +24,7 @@ resource "lightstep_dashboard" "aws_s3_dashboard" {
       hidden       = false
       query_string = <<EOT
 metric aws.s3.all_requests_max | latest | group_by [], sum
+
 EOT
     }
 
@@ -40,6 +41,7 @@ EOT
       hidden       = false
       query_string = <<EOT
 metric aws.s3.bytes_downloaded_max | latest | group_by [], sum
+
 EOT
     }
 
@@ -49,6 +51,7 @@ EOT
       hidden       = false
       query_string = <<EOT
 metric aws.s3.bytes_uploaded_max | latest | group_by [], sum
+
 EOT
     }
 
@@ -65,6 +68,7 @@ EOT
       hidden       = false
       query_string = <<EOT
 metric aws.s3.first_byte_latency_max | latest | group_by [], sum
+
 EOT
     }
 
@@ -74,6 +78,7 @@ EOT
       hidden       = false
       query_string = <<EOT
 metric aws.s3.total_request_latency_max | latest | group_by [], sum
+
 EOT
     }
 
@@ -90,6 +95,7 @@ EOT
       hidden       = false
       query_string = <<EOT
 metric aws.s3.5xx_errors_count | delta | group_by [], sum
+
 EOT
     }
 
@@ -99,10 +105,10 @@ EOT
       hidden       = false
       query_string = <<EOT
 metric aws.s3.4xx_errors_count | delta | group_by [], sum
+
 EOT
     }
 
   }
 
 }
-


### PR DESCRIPTION
This PR does 2 things:  (1) updates 5 dashboards which were not using UQL and (2) updates the descriptions of those dashboards to be present, but minimal.

- [s3] reformat for prebuilt
- [lambda] reformat for prebuilt
- [elasticache-redis] reformat for prebuilt
- [route53] reformat for prebuilt
- [amplify] reformat for prebuilt
- update descriptions
