### PR TITLE
Reformat more prebuilt dashboards

### DIFF
--- a/modules/aurora-dashboard/main.tf
+++ b/modules/aurora-dashboard/main.tf
@@ -2,15 +2,16 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.70.1"
+      version = "~> 1.70.10"
     }
   }
   required_version = ">= v1.0.11"
 }
 
-resource "lightstep_metric_dashboard" "aws_aurora_dashboard" {
-  project_name   = var.lightstep_project
-  dashboard_name = "AWS AURORA"
+resource "lightstep_dashboard" "aws_aurora_dashboard" {
+  project_name          = var.lightstep_project
+  dashboard_name        = "AWS AURORA"
+  dashboard_description = ""
 
   chart {
     name = "Binary lag replica DB cluster"
@@ -18,67 +19,39 @@ resource "lightstep_metric_dashboard" "aws_aurora_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_binlog_replica_lag_count"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_binlog_replica_lag_count | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_binlog_replica_lag_max"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "b"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_binlog_replica_lag_max | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_binlog_replica_lag_min"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "c"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_binlog_replica_lag_min | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_binlog_replica_lag_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "d"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_binlog_replica_lag_sum | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
   }
@@ -89,67 +62,39 @@ resource "lightstep_metric_dashboard" "aws_aurora_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_dml_rejected_master_full_count"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_dml_rejected_master_full_count | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_dml_rejected_master_full_max"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "b"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_dml_rejected_master_full_max | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_dml_rejected_master_full_min"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "c"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_dml_rejected_master_full_min | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_dml_rejected_master_full_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "d"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_dml_rejected_master_full_sum | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
   }
@@ -160,67 +105,39 @@ resource "lightstep_metric_dashboard" "aws_aurora_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_pq_request_attempted_count"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_pq_request_attempted_count | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_pq_request_attempted_max"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "b"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_pq_request_attempted_max | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_pq_request_attempted_min"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "c"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_pq_request_attempted_min | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_pq_request_attempted_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "d"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_pq_request_attempted_sum | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
   }
@@ -231,67 +148,39 @@ resource "lightstep_metric_dashboard" "aws_aurora_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_pq_request_executed_count"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "a"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_pq_request_executed_count | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_pq_request_executed_max"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "b"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_pq_request_executed_max | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_pq_request_executed_min"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "c"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_pq_request_executed_min | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-
-      metric              = "aws.rds.aurora_pq_request_attempted_sum"
-      timeseries_operator = "delta"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["DBClusterIdentifier"]
-      }
-
+      query_name   = "d"
+      display      = "bar"
+      hidden       = false
+      query_string = <<EOT
+metric aws.rds.aurora_pq_request_attempted_sum | delta | group_by ["DBClusterIdentifier"], sum
+EOT
     }
 
   }

--- a/modules/aurora-dashboard/main.tf
+++ b/modules/aurora-dashboard/main.tf
@@ -10,8 +10,8 @@ terraform {
 
 resource "lightstep_dashboard" "aws_aurora_dashboard" {
   project_name          = var.lightstep_project
-  dashboard_name        = "AWS AURORA"
-  dashboard_description = ""
+  dashboard_name        = "AWS Aurora"
+  dashboard_description = "Monitor AWS Aurora with this overview dashboard."
 
   chart {
     name = "Binary lag replica DB cluster"

--- a/modules/ecs-dashboard/main.tf
+++ b/modules/ecs-dashboard/main.tf
@@ -8,9 +8,10 @@ terraform {
   required_version = ">= v1.0.11"
 }
 
-resource "lightstep_metric_dashboard" "aws_ecs_dashboard" {
-  project_name   = var.lightstep_project
-  dashboard_name = "AWS ECS"
+resource "lightstep_dashboard" "aws_ecs_dashboard" {
+  project_name          = var.lightstep_project
+  dashboard_name        = "AWS ECS"
+  dashboard_description = "Monitor AWS ECS with this summary dashboard."
 
   chart {
     name = "CPU Utilization"
@@ -18,19 +19,12 @@ resource "lightstep_metric_dashboard" "aws_ecs_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.ecs.cpu_utilization_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["ClusterName", ]
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.ecs.cpu_utilization_max | latest | group_by ["ClusterName"], sum
+EOT
     }
 
   }
@@ -41,19 +35,12 @@ resource "lightstep_metric_dashboard" "aws_ecs_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.ecs.memory_utilization_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["ClusterName", ]
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.ecs.memory_utilization_max | latest | group_by ["ClusterName"], sum
+EOT
     }
 
   }
@@ -64,19 +51,12 @@ resource "lightstep_metric_dashboard" "aws_ecs_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.ecs.cpu_reservation_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = ["ClusterName", ]
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.ecs.cpu_reservation_max | latest | group_by ["ClusterName"], sum
+EOT
     }
 
   }
@@ -87,19 +67,12 @@ resource "lightstep_metric_dashboard" "aws_ecs_dashboard" {
     type = "timeseries"
 
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-
-      metric              = "aws.ecs.memory_reservation_max"
-      timeseries_operator = "last"
-
-
-      group_by {
-        aggregation_method = "sum"
-        keys               = []
-      }
-
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric aws.ecs.memory_reservation_max | latest | group_by [], sum
+EOT
     }
 
   }

--- a/modules/natgateway-dashboard/main.tf
+++ b/modules/natgateway-dashboard/main.tf
@@ -12,7 +12,7 @@ terraform {
 resource "lightstep_dashboard" "aws_natgateway_dashboard" {
   project_name   = var.lightstep_project
   dashboard_name = "AWS NAT Gateway"
-  description = "Monitor AWS NAT Gateway with this summary dashboard."
+  dashboard_description = "Monitor AWS NAT Gateway with this summary dashboard."
 
   chart {
     name = "Bytes In From Destination"

--- a/modules/natgateway-dashboard/main.tf
+++ b/modules/natgateway-dashboard/main.tf
@@ -10,8 +10,8 @@ terraform {
 
 
 resource "lightstep_dashboard" "aws_natgateway_dashboard" {
-  project_name   = var.lightstep_project
-  dashboard_name = "AWS NAT Gateway"
+  project_name          = var.lightstep_project
+  dashboard_name        = "AWS NAT Gateway"
   dashboard_description = "Monitor AWS NAT Gateway with this summary dashboard."
 
   chart {

--- a/modules/sns-dashboard/main.tf
+++ b/modules/sns-dashboard/main.tf
@@ -8,11 +8,10 @@ terraform {
   required_version = ">= v1.0.11"
 }
 
-
-resource "lightstep_dashboard" "aws_sns_summary_dashboard" {
+resource "lightstep_dashboard" "aws_sns_dashboard" {
   project_name          = var.lightstep_project
   dashboard_name        = "AWS SNS"
-  dashboard_description = "Monitor AWS SNS to collect, view, and analyze metrics for every active Amazon SNS notification."
+  dashboard_description = "Monitor AWS SNS performance with this summary dashboard."
 
   chart {
     name = "Messages Published"
@@ -25,7 +24,8 @@ resource "lightstep_dashboard" "aws_sns_summary_dashboard" {
       hidden       = false
       query_string = <<EOT
   metric aws.sns.number_of_messages_published_count | delta | group_by [], sum
-  EOT
+
+EOT
     }
 
   }
@@ -41,7 +41,8 @@ resource "lightstep_dashboard" "aws_sns_summary_dashboard" {
       hidden       = false
       query_string = <<EOT
   metric aws.sns.publish_size_max | latest | group_by [], sum
-  EOT
+
+EOT
     }
 
   }

--- a/modules/sqs-dashboard/main.tf
+++ b/modules/sqs-dashboard/main.tf
@@ -8,7 +8,6 @@ terraform {
   required_version = ">= v1.0.11"
 }
 
-
 resource "lightstep_dashboard" "aws_sqs_dashboard" {
   project_name          = var.lightstep_project
   dashboard_name        = "AWS SQS"
@@ -25,6 +24,7 @@ resource "lightstep_dashboard" "aws_sqs_dashboard" {
       hidden       = false
       query_string = <<EOT
 metric aws.sqs.number_of_messages_sent_count | delta | group_by [], sum
+
 EOT
     }
 
@@ -34,6 +34,7 @@ EOT
       hidden       = false
       query_string = <<EOT
 metric aws.sqs.number_of_messages_received_count | delta | group_by [], sum
+
 EOT
     }
 
@@ -50,6 +51,7 @@ EOT
       hidden       = false
       query_string = <<EOT
 metric aws.sqs.approximate_age_of_oldest_message_max | latest | group_by [], sum
+
 EOT
     }
 
@@ -66,6 +68,7 @@ EOT
       hidden       = false
       query_string = <<EOT
 metric aws.sqs.approximate_number_of_messages_visible_count | rate | group_by [], sum
+
 EOT
     }
 
@@ -75,6 +78,7 @@ EOT
       hidden       = false
       query_string = <<EOT
 metric aws.sqs.approximate_number_of_messages_delayed_count | delta | group_by [], sum
+
 EOT
     }
 
@@ -91,6 +95,7 @@ EOT
       hidden       = false
       query_string = <<EOT
 metric aws.sqs.number_of_empty_receives_count | delta | group_by [], sum
+
 EOT
     }
 
@@ -107,10 +112,10 @@ EOT
       hidden       = false
       query_string = <<EOT
 metric aws.sqs.sent_message_size_max | latest | group_by [], sum
+
 EOT
     }
 
   }
 
 }
-


### PR DESCRIPTION
This PR does 2 things: (1) updates 5 dashboards which were not using UQL and (2) updates the descriptions of those dashboards to be present, but minimal.
- [ecs] ECS to UQL
- [sqs] reformat to UQL
- [sns] reformat to UQL
- [aurora] reformat to UQL
