### PR TITLE
Repair SNS output var

### DIFF
--- a/modules/sns-dashboard/outputs.tf
+++ b/modules/sns-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_sns_summary_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_sns_dashboard.id}"
   description = "SNS Dashboard URL"
 }


### PR DESCRIPTION
We rewrote some aspects of this file and stopped using the _summary_
indicator in the resource name.
