### PR TITLE
Use AWS instead of Amazon name

### DIFF
--- a/modules/athena-dashboard/main.tf
+++ b/modules/athena-dashboard/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 resource "lightstep_dashboard" "aws_athena_dashboard" {
   project_name   = var.lightstep_project
-  dashboard_name = "Amazon Athena"
+  dashboard_name = "AWS Athena"
 
   chart {
     name = "Total Execution Time"


### PR DESCRIPTION
This is the consistent way to name these dashboards. And it is also necessary for managing these with some automation.