### PR TITLE
Revert cloud_observability_ in variable names to lightstep_

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,16 +22,16 @@ init:
 
 apply:
 	terraform apply \
-		-var="cloud_observability_organization=LightStep" \
-		-var="cloud_observability_env=staging" \
-		-var="cloud_observability_project=dev-integrations" \
-		-var="cloud_observability_api_key_env_var=LIGHTSTEP_API_KEY"
+		-var="lightstep_organization=LightStep" \
+		-var="lightstep_env=staging" \
+		-var="lightstep_project=dev-integrations" \
+		-var="lightstep_api_key_env_var=LIGHTSTEP_API_KEY"
 
 destroy:
 	terraform destroy \
-		-var="cloud_observability_organization=LightStep" \
-		-var="cloud_observability_env=staging" \
-		-var="cloud_observability_project=dev-integrations" \
-		-var="cloud_observability_api_key_env_var=LIGHTSTEP_API_KEY"
+		-var="lightstep_organization=LightStep" \
+		-var="lightstep_env=staging" \
+		-var="lightstep_project=dev-integrations" \
+		-var="lightstep_api_key_env_var=LIGHTSTEP_API_KEY"
 
 fresh: clean init apply

--- a/examples/applicationelb-dashboard/main.tf
+++ b/examples/applicationelb-dashboard/main.tf
@@ -18,6 +18,6 @@ module "lightstep_applicationelb_dashboard" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
   # source = "git::git@github.com:lightstep/terraform-lightstep-aws-dashboards.git//modules/ec2-dashboard?ref=v0.0.1"
-  source                      = "../../modules/applicationelb-dashboard"
+  source            = "../../modules/applicationelb-dashboard"
   lightstep_project = var.lightstep_project
 }

--- a/examples/applicationelb-dashboard/main.tf
+++ b/examples/applicationelb-dashboard/main.tf
@@ -9,9 +9,9 @@ terraform {
 }
 
 provider "lightstep" {
-  api_key_env_var = var.cloud_observability_api_key_env_var
-  organization    = var.cloud_observability_organization
-  environment     = var.cloud_observability_env
+  api_key_env_var = var.lightstep_api_key_env_var
+  organization    = var.lightstep_organization
+  environment     = var.lightstep_env
 }
 
 module "lightstep_applicationelb_dashboard" {
@@ -19,5 +19,5 @@ module "lightstep_applicationelb_dashboard" {
   # to a specific version of the modules, such as the following example:
   # source = "git::git@github.com:lightstep/terraform-lightstep-aws-dashboards.git//modules/ec2-dashboard?ref=v0.0.1"
   source                      = "../../modules/applicationelb-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }

--- a/examples/applicationelb-dashboard/variables.tf
+++ b/examples/applicationelb-dashboard/variables.tf
@@ -1,20 +1,20 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }
 
-variable "cloud_observability_organization" {
+variable "lightstep_organization" {
   description = "Name of Cloud Observability organization"
   type        = string
 }
 
-variable "cloud_observability_env" {
+variable "lightstep_env" {
   description = "Cloud Observability environment"
   type        = string
   default     = "public"
 }
 
-variable "cloud_observability_api_key_env_var" {
+variable "lightstep_api_key_env_var" {
   description = "Name of the local environment variable that contains the Cloud Observability API key"
   type        = string
   default     = "LIGHTSTEP_API_KEY"

--- a/examples/ec2-dashboard/main.tf
+++ b/examples/ec2-dashboard/main.tf
@@ -18,7 +18,7 @@ module "lightstep_ec2_dashboard" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
   # source = "git::git@github.com:lightstep/terraform-lightstep-aws-dashboards.git//modules/ec2-dashboard?ref=v0.0.1"
-  source                      = "../../modules/ec2-dashboard"
+  source            = "../../modules/ec2-dashboard"
   lightstep_project = var.lightstep_project
-  aws_region                  = "us-west-2"
+  aws_region        = "us-west-2"
 }

--- a/examples/ec2-dashboard/main.tf
+++ b/examples/ec2-dashboard/main.tf
@@ -19,6 +19,6 @@ module "lightstep_ec2_dashboard" {
   # to a specific version of the modules, such as the following example:
   # source = "git::git@github.com:lightstep/terraform-lightstep-aws-dashboards.git//modules/ec2-dashboard?ref=v0.0.1"
   source                      = "../../modules/ec2-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
   aws_region                  = "us-west-2"
 }

--- a/examples/ec2-dashboard/variables.tf
+++ b/examples/ec2-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/examples/rds-dashboard/main.tf
+++ b/examples/rds-dashboard/main.tf
@@ -19,6 +19,6 @@ module "lightstep_ec2_dashboard" {
   # to a specific version of the modules, such as the following example:
   # source = "git::git@github.com:lightstep/terraform-lightstep-aws-dashboards.git//modules/ec2-dashboard?ref=v0.0.1"
   source                      = "../../modules/rds-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
   aws_region                  = "us-west-2"
 }

--- a/examples/rds-dashboard/main.tf
+++ b/examples/rds-dashboard/main.tf
@@ -18,7 +18,7 @@ module "lightstep_ec2_dashboard" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
   # source = "git::git@github.com:lightstep/terraform-lightstep-aws-dashboards.git//modules/ec2-dashboard?ref=v0.0.1"
-  source                      = "../../modules/rds-dashboard"
+  source            = "../../modules/rds-dashboard"
   lightstep_project = var.lightstep_project
-  aws_region                  = "us-west-2"
+  aws_region        = "us-west-2"
 }

--- a/examples/rds-dashboard/variables.tf
+++ b/examples/rds-dashboard/variables.tf
@@ -1,20 +1,20 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }
 
-variable "cloud_observability_organization" {
+variable "lightstep_organization" {
   description = "Name of Cloud Observability organization"
   type        = string
 }
 
-variable "cloud_observability_env" {
+variable "lightstep_env" {
   description = "Cloud Observability environment"
   type        = string
   default     = "public"
 }
 
-variable "cloud_observability_api_key_env_var" {
+variable "lightstep_api_key_env_var" {
   description = "Name of the local environment variable that contains the Cloud Observability API key"
   type        = string
   default     = "LIGHTSTEP_API_KEY"

--- a/main.tf
+++ b/main.tf
@@ -9,202 +9,202 @@ terraform {
 }
 
 provider "lightstep" {
-  api_key_env_var = var.cloud_observability_api_key_env_var
-  organization    = var.cloud_observability_organization
-  environment     = var.cloud_observability_env
+  api_key_env_var = var.lightstep_api_key_env_var
+  organization    = var.lightstep_organization
+  environment     = var.lightstep_env
 }
 
-module "cloud_observability_amplify_dashboard" {
+module "lightstep_amplify_dashboard" {
   source                      = "./modules/amplify-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_apigateway_dashboard" {
+module "lightstep_apigateway_dashboard" {
   source                      = "./modules/apigateway-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_applicationelb_dashboard" {
+module "lightstep_applicationelb_dashboard" {
   source                      = "./modules/applicationelb-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_athena_dashboard" {
+module "lightstep_athena_dashboard" {
   source                      = "./modules/athena-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_aurora_dashboard" {
+module "lightstep_aurora_dashboard" {
   source                      = "./modules/aurora-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_autoscaling_dashboard" {
+module "lightstep_autoscaling_dashboard" {
   source                      = "./modules/autoscaling-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_backup_dashboard" {
+module "lightstep_backup_dashboard" {
   source                      = "./modules/backup-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_certificatemanager_dashboard" {
+module "lightstep_certificatemanager_dashboard" {
   source                      = "./modules/certificatemanager-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_chatbot_dashboard" {
+module "lightstep_chatbot_dashboard" {
   source                      = "./modules/chatbot-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_chime_dashboard" {
+module "lightstep_chime_dashboard" {
   source                      = "./modules/chime-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_cloudfront_dashboard" {
+module "lightstep_cloudfront_dashboard" {
   source                      = "./modules/cloudfront-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_cloudhsm_dashboard" {
+module "lightstep_cloudhsm_dashboard" {
   source                      = "./modules/cloudhsm-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_cloudtrail_dashboard" {
+module "lightstep_cloudtrail_dashboard" {
   source                      = "./modules/cloudtrail-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_cognito_dashboard" {
+module "lightstep_cognito_dashboard" {
   source                      = "./modules/cognito-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_dynamodb_dashboard" {
+module "lightstep_dynamodb_dashboard" {
   source                      = "./modules/dynamodb-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_ebs_dashboard" {
+module "lightstep_ebs_dashboard" {
   source                      = "./modules/ebs-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_ec2_dashboard" {
+module "lightstep_ec2_dashboard" {
   source                      = "./modules/ec2-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_ecs_dashboard" {
+module "lightstep_ecs_dashboard" {
   source                      = "./modules/ecs-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_efs_dashboard" {
+module "lightstep_efs_dashboard" {
   source                      = "./modules/efs-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_eks_node_dashboard" {
+module "lightstep_eks_node_dashboard" {
   source                      = "./modules/eks-node-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_eks_pod_dashboard" {
+module "lightstep_eks_pod_dashboard" {
   source                      = "./modules/eks-pod-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_elasticache_redis_dashboard" {
+module "lightstep_elasticache_redis_dashboard" {
   source                      = "./modules/elasticache-redis-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_elasticmapreduce_dashboard" {
+module "lightstep_elasticmapreduce_dashboard" {
   source                      = "./modules/elasticmapreduce-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_eventbridge_dashboard" {
+module "lightstep_eventbridge_dashboard" {
   source                      = "./modules/eventbridge-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_inspector_dashboard" {
+module "lightstep_inspector_dashboard" {
   source                      = "./modules/inspector-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_kinesis_dashboard" {
+module "lightstep_kinesis_dashboard" {
   source                      = "./modules/kinesis-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_lambda_dashboard" {
+module "lightstep_lambda_dashboard" {
   source                      = "./modules/lambda-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_msk_dashboard" {
+module "lightstep_msk_dashboard" {
   source                      = "./modules/msk-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_msk_topic_dashboard" {
+module "lightstep_msk_topic_dashboard" {
   source                      = "./modules/msk-topic-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_natgateway_dashboard" {
+module "lightstep_natgateway_dashboard" {
   source                      = "./modules/natgateway-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_networkfirewall_dashboard" {
+module "lightstep_networkfirewall_dashboard" {
   source                      = "./modules/networkfirewall-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_rds_dashboard" {
+module "lightstep_rds_dashboard" {
   source                      = "./modules/rds-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_redshift_dashboard" {
+module "lightstep_redshift_dashboard" {
   source                      = "./modules/redshift-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_route53_dashboard" {
+module "lightstep_route53_dashboard" {
   source                      = "./modules/route53-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_s3_dashboard" {
+module "lightstep_s3_dashboard" {
   source                      = "./modules/s3-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_ses_dashboard" {
+module "lightstep_ses_dashboard" {
   source                      = "./modules/ses-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_sns_dashboard" {
+module "lightstep_sns_dashboard" {
   source                      = "./modules/sns-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_sqs_dashboard" {
+module "lightstep_sqs_dashboard" {
   source                      = "./modules/sqs-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }
 
-module "cloud_observability_stepfunctions_dashboard" {
+module "lightstep_stepfunctions_dashboard" {
   source                      = "./modules/stepfunctions-dashboard"
-  cloud_observability_project = var.cloud_observability_project
+  lightstep_project = var.lightstep_project
 }

--- a/main.tf
+++ b/main.tf
@@ -15,196 +15,196 @@ provider "lightstep" {
 }
 
 module "lightstep_amplify_dashboard" {
-  source                      = "./modules/amplify-dashboard"
+  source            = "./modules/amplify-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_apigateway_dashboard" {
-  source                      = "./modules/apigateway-dashboard"
+  source            = "./modules/apigateway-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_applicationelb_dashboard" {
-  source                      = "./modules/applicationelb-dashboard"
+  source            = "./modules/applicationelb-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_athena_dashboard" {
-  source                      = "./modules/athena-dashboard"
+  source            = "./modules/athena-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_aurora_dashboard" {
-  source                      = "./modules/aurora-dashboard"
+  source            = "./modules/aurora-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_autoscaling_dashboard" {
-  source                      = "./modules/autoscaling-dashboard"
+  source            = "./modules/autoscaling-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_backup_dashboard" {
-  source                      = "./modules/backup-dashboard"
+  source            = "./modules/backup-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_certificatemanager_dashboard" {
-  source                      = "./modules/certificatemanager-dashboard"
+  source            = "./modules/certificatemanager-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_chatbot_dashboard" {
-  source                      = "./modules/chatbot-dashboard"
+  source            = "./modules/chatbot-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_chime_dashboard" {
-  source                      = "./modules/chime-dashboard"
+  source            = "./modules/chime-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_cloudfront_dashboard" {
-  source                      = "./modules/cloudfront-dashboard"
+  source            = "./modules/cloudfront-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_cloudhsm_dashboard" {
-  source                      = "./modules/cloudhsm-dashboard"
+  source            = "./modules/cloudhsm-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_cloudtrail_dashboard" {
-  source                      = "./modules/cloudtrail-dashboard"
+  source            = "./modules/cloudtrail-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_cognito_dashboard" {
-  source                      = "./modules/cognito-dashboard"
+  source            = "./modules/cognito-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_dynamodb_dashboard" {
-  source                      = "./modules/dynamodb-dashboard"
+  source            = "./modules/dynamodb-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_ebs_dashboard" {
-  source                      = "./modules/ebs-dashboard"
+  source            = "./modules/ebs-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_ec2_dashboard" {
-  source                      = "./modules/ec2-dashboard"
+  source            = "./modules/ec2-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_ecs_dashboard" {
-  source                      = "./modules/ecs-dashboard"
+  source            = "./modules/ecs-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_efs_dashboard" {
-  source                      = "./modules/efs-dashboard"
+  source            = "./modules/efs-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_eks_node_dashboard" {
-  source                      = "./modules/eks-node-dashboard"
+  source            = "./modules/eks-node-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_eks_pod_dashboard" {
-  source                      = "./modules/eks-pod-dashboard"
+  source            = "./modules/eks-pod-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_elasticache_redis_dashboard" {
-  source                      = "./modules/elasticache-redis-dashboard"
+  source            = "./modules/elasticache-redis-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_elasticmapreduce_dashboard" {
-  source                      = "./modules/elasticmapreduce-dashboard"
+  source            = "./modules/elasticmapreduce-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_eventbridge_dashboard" {
-  source                      = "./modules/eventbridge-dashboard"
+  source            = "./modules/eventbridge-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_inspector_dashboard" {
-  source                      = "./modules/inspector-dashboard"
+  source            = "./modules/inspector-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_kinesis_dashboard" {
-  source                      = "./modules/kinesis-dashboard"
+  source            = "./modules/kinesis-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_lambda_dashboard" {
-  source                      = "./modules/lambda-dashboard"
+  source            = "./modules/lambda-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_msk_dashboard" {
-  source                      = "./modules/msk-dashboard"
+  source            = "./modules/msk-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_msk_topic_dashboard" {
-  source                      = "./modules/msk-topic-dashboard"
+  source            = "./modules/msk-topic-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_natgateway_dashboard" {
-  source                      = "./modules/natgateway-dashboard"
+  source            = "./modules/natgateway-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_networkfirewall_dashboard" {
-  source                      = "./modules/networkfirewall-dashboard"
+  source            = "./modules/networkfirewall-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_rds_dashboard" {
-  source                      = "./modules/rds-dashboard"
+  source            = "./modules/rds-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_redshift_dashboard" {
-  source                      = "./modules/redshift-dashboard"
+  source            = "./modules/redshift-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_route53_dashboard" {
-  source                      = "./modules/route53-dashboard"
+  source            = "./modules/route53-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_s3_dashboard" {
-  source                      = "./modules/s3-dashboard"
+  source            = "./modules/s3-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_ses_dashboard" {
-  source                      = "./modules/ses-dashboard"
+  source            = "./modules/ses-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_sns_dashboard" {
-  source                      = "./modules/sns-dashboard"
+  source            = "./modules/sns-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_sqs_dashboard" {
-  source                      = "./modules/sqs-dashboard"
+  source            = "./modules/sqs-dashboard"
   lightstep_project = var.lightstep_project
 }
 
 module "lightstep_stepfunctions_dashboard" {
-  source                      = "./modules/stepfunctions-dashboard"
+  source            = "./modules/stepfunctions-dashboard"
   lightstep_project = var.lightstep_project
 }

--- a/modules/amplify-dashboard/main.tf
+++ b/modules/amplify-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_amplify_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS Amplify"
   dashboard_description = "Monitor AWS Amplify with this summary dashboard."
 

--- a/modules/amplify-dashboard/outputs.tf
+++ b/modules/amplify-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_amplify_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_amplify_dashboard.id}"
   description = "Amplify Dashboard URL"
 }

--- a/modules/amplify-dashboard/variables.tf
+++ b/modules/amplify-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/apigateway-dashboard/main.tf
+++ b/modules/apigateway-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_apigateway_dashboard" {
-  project_name   = var.cloud_observability_project
+  project_name   = var.lightstep_project
   dashboard_name = "AWS API Gateway"
 
   chart {

--- a/modules/apigateway-dashboard/outputs.tf
+++ b/modules/apigateway-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_apigateway_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_apigateway_dashboard.id}"
   description = "SNS Dashboard URL"
 }

--- a/modules/apigateway-dashboard/variables.tf
+++ b/modules/apigateway-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/applicationelb-dashboard/main.tf
+++ b/modules/applicationelb-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_applicationelb_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS Application ELB"
   dashboard_description = "Monitor AWS Application ELB with this overview dashboard."
 

--- a/modules/applicationelb-dashboard/outputs.tf
+++ b/modules/applicationelb-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_applicationelb_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_applicationelb_dashboard.id}"
   description = "Application ELB Dashboard URL"
 }

--- a/modules/applicationelb-dashboard/variables.tf
+++ b/modules/applicationelb-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/athena-dashboard/main.tf
+++ b/modules/athena-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_athena_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS Athena"
   dashboard_description = "Monitor AWS Athena with this dashboard."
 

--- a/modules/athena-dashboard/outputs.tf
+++ b/modules/athena-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_athena_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_athena_dashboard.id}"
   description = "Athena Dashboard URL"
 }

--- a/modules/athena-dashboard/variables.tf
+++ b/modules/athena-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/aurora-dashboard/main.tf
+++ b/modules/aurora-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_aurora_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS Aurora"
   dashboard_description = "Monitor AWS Aurora with this overview dashboard."
 

--- a/modules/aurora-dashboard/outputs.tf
+++ b/modules/aurora-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_aurora_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_aurora_dashboard.id}"
   description = "Aurora Dashboard URL"
 }

--- a/modules/aurora-dashboard/variables.tf
+++ b/modules/aurora-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/autoscaling-dashboard/main.tf
+++ b/modules/autoscaling-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_autoscaling_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS AutoScaling"
   dashboard_description = "Monitor AWS AutoScaling with this dashboard."
 

--- a/modules/autoscaling-dashboard/outputs.tf
+++ b/modules/autoscaling-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_autoscaling_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_autoscaling_dashboard.id}"
   description = "AutoScaling Dashboard URL"
 }

--- a/modules/autoscaling-dashboard/variables.tf
+++ b/modules/autoscaling-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/backup-dashboard/main.tf
+++ b/modules/backup-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_backup_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS Backup"
   dashboard_description = "Monitor AWS Backup with this dashboard."
 

--- a/modules/backup-dashboard/outputs.tf
+++ b/modules/backup-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_backup_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_backup_dashboard.id}"
   description = "Backup Dashboard URL"
 }

--- a/modules/backup-dashboard/variables.tf
+++ b/modules/backup-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/certificatemanager-dashboard/main.tf
+++ b/modules/certificatemanager-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_certificatemanager_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS Certificate Manager"
   dashboard_description = "Monitor AWS Certificate Manager with this dashboard."
 

--- a/modules/certificatemanager-dashboard/outputs.tf
+++ b/modules/certificatemanager-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_certificatemanager_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_certificatemanager_dashboard.id}"
   description = "Certificate Manaager Dashboard URL"
 }

--- a/modules/certificatemanager-dashboard/variables.tf
+++ b/modules/certificatemanager-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/chatbot-dashboard/main.tf
+++ b/modules/chatbot-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_chatbot_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS Chatbot"
   dashboard_description = "Monitor AWS Chatbot with this dashboard."
 

--- a/modules/chatbot-dashboard/outputs.tf
+++ b/modules/chatbot-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_chatbot_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_chatbot_dashboard.id}"
   description = "Chatbot Dashboard URL"
 }

--- a/modules/chatbot-dashboard/variables.tf
+++ b/modules/chatbot-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/chime-dashboard/main.tf
+++ b/modules/chime-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_chime_dashboard" {
-  project_name   = var.cloud_observability_project
+  project_name   = var.lightstep_project
   dashboard_name = "AWS Chime SDK"
 
   chart {

--- a/modules/chime-dashboard/outputs.tf
+++ b/modules/chime-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_chime_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_chime_dashboard.id}"
   description = "Chime Dashboard URL"
 }

--- a/modules/chime-dashboard/variables.tf
+++ b/modules/chime-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/cloudfront-dashboard/main.tf
+++ b/modules/cloudfront-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_cloudfront_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS CloudFront"
   dashboard_description = "Monitor AWS CloudFront with this dashboard."
 

--- a/modules/cloudfront-dashboard/outputs.tf
+++ b/modules/cloudfront-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_cloudfront_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_cloudfront_dashboard.id}"
   description = "CLOUDFRONT Dashboard URL"
 }

--- a/modules/cloudfront-dashboard/variables.tf
+++ b/modules/cloudfront-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/cloudhsm-dashboard/main.tf
+++ b/modules/cloudhsm-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_cloudhsm_dashboard" {
-  project_name   = var.cloud_observability_project
+  project_name   = var.lightstep_project
   dashboard_name = "AWS CloudHSM"
 
   chart {

--- a/modules/cloudhsm-dashboard/outputs.tf
+++ b/modules/cloudhsm-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_cloudhsm_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_cloudhsm_dashboard.id}"
   description = "CLOUDHSM Dashboard URL"
 }

--- a/modules/cloudhsm-dashboard/variables.tf
+++ b/modules/cloudhsm-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/cloudtrail-dashboard/main.tf
+++ b/modules/cloudtrail-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_cloudtrail_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS CloudTrail"
   dashboard_description = "Monitor AWS CloudTrail with this dashboard."
 

--- a/modules/cloudtrail-dashboard/outputs.tf
+++ b/modules/cloudtrail-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_cloudtrail_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_cloudtrail_dashboard.id}"
   description = "CloudTrail Dashboard URL"
 }

--- a/modules/cloudtrail-dashboard/variables.tf
+++ b/modules/cloudtrail-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/cognito-dashboard/main.tf
+++ b/modules/cognito-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_cognito_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS Cognito"
   dashboard_description = "Monitor AWS Cognito with this dashboard."
 

--- a/modules/cognito-dashboard/outputs.tf
+++ b/modules/cognito-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_cognito_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_cognito_dashboard.id}"
   description = "COGNITO Dashboard URL"
 }

--- a/modules/cognito-dashboard/variables.tf
+++ b/modules/cognito-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/dynamodb-dashboard/main.tf
+++ b/modules/dynamodb-dashboard/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 
 resource "lightstep_dashboard" "aws_dynamodb_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS DynamoDB"
   dashboard_description = "Monitor DynamoDB with this overview dashboard."
 

--- a/modules/dynamodb-dashboard/outputs.tf
+++ b/modules/dynamodb-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_dynamodb_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_dynamodb_dashboard.id}"
   description = "DynamoDB Dashboard URL"
 }

--- a/modules/dynamodb-dashboard/variables.tf
+++ b/modules/dynamodb-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/ebs-dashboard/main.tf
+++ b/modules/ebs-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_ebs_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS EBS"
   dashboard_description = "Monitor your EBS Volumes with this dashboard."
 

--- a/modules/ebs-dashboard/outputs.tf
+++ b/modules/ebs-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_ebs_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_ebs_dashboard.id}"
   description = "OpenTelemetry AWS EBS Dashboard URL"
 }

--- a/modules/ebs-dashboard/variables.tf
+++ b/modules/ebs-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/ec2-dashboard/main.tf
+++ b/modules/ec2-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_ec2_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS EC2"
   dashboard_description = "Monitor AWS EC2 - compute - performance metrics."
 

--- a/modules/ec2-dashboard/outputs.tf
+++ b/modules/ec2-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_ec2_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_ec2_dashboard.id}"
   description = "EC2 Dashboard URL"
 }

--- a/modules/ec2-dashboard/variables.tf
+++ b/modules/ec2-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/ecs-dashboard/main.tf
+++ b/modules/ecs-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_ecs_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS ECS"
   dashboard_description = "Monitor AWS ECS with this summary dashboard."
 

--- a/modules/ecs-dashboard/outputs.tf
+++ b/modules/ecs-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_ecs_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_ecs_dashboard.id}"
   description = "ECS Dashboard URL"
 }

--- a/modules/ecs-dashboard/variables.tf
+++ b/modules/ecs-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/efs-dashboard/main.tf
+++ b/modules/efs-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_efs_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS EFS"
   dashboard_description = ""
 

--- a/modules/efs-dashboard/outputs.tf
+++ b/modules/efs-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_efs_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_efs_dashboard.id}"
   description = "EFS Dashboard URL"
 }

--- a/modules/efs-dashboard/variables.tf
+++ b/modules/efs-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/eks-node-dashboard/main.tf
+++ b/modules/eks-node-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_eks_node_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS EKS Node"
   dashboard_description = "Monitor AWS EKS Node with this dashboard."
 

--- a/modules/eks-node-dashboard/outputs.tf
+++ b/modules/eks-node-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_eks_node_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_eks_node_dashboard.id}"
   description = "EKS NODE Dashboard URL"
 }

--- a/modules/eks-node-dashboard/variables.tf
+++ b/modules/eks-node-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/eks-pod-dashboard/main.tf
+++ b/modules/eks-pod-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_eks_pod_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS EKS Pod"
   dashboard_description = "Monitor AWS EKS Pods with this summary dashboard."
 

--- a/modules/eks-pod-dashboard/outputs.tf
+++ b/modules/eks-pod-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_eks_pod_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_eks_pod_dashboard.id}"
   description = "EKS POD Dashboard URL"
 }

--- a/modules/eks-pod-dashboard/variables.tf
+++ b/modules/eks-pod-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/elasticache-redis-dashboard/main.tf
+++ b/modules/elasticache-redis-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_elasticache_redis_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS ElastiCache (Redis)"
   dashboard_description = "Monitor AWS ElastiCache (Redis) with this overview dashboard."
 

--- a/modules/elasticache-redis-dashboard/outputs.tf
+++ b/modules/elasticache-redis-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_elasticache_redis_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_elasticache_redis_dashboard.id}"
   description = "Elasticache Redis Dashboard URL"
 }

--- a/modules/elasticache-redis-dashboard/variables.tf
+++ b/modules/elasticache-redis-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/elasticmapreduce-dashboard/main.tf
+++ b/modules/elasticmapreduce-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_elasticmapreduce_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS EMR Hadoop 2"
   dashboard_description = "Monitor AWS EMR with this dashboard."
 

--- a/modules/elasticmapreduce-dashboard/outputs.tf
+++ b/modules/elasticmapreduce-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_elasticmapreduce_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_elasticmapreduce_dashboard.id}"
   description = "Elastic Map Reduce Dashboard URL"
 }

--- a/modules/elasticmapreduce-dashboard/variables.tf
+++ b/modules/elasticmapreduce-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/eventbridge-dashboard/main.tf
+++ b/modules/eventbridge-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_eventbridge_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS EventBridge"
   dashboard_description = "Monitor AWS EventBridge in this overview."
 

--- a/modules/eventbridge-dashboard/outputs.tf
+++ b/modules/eventbridge-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_eventbridge_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_eventbridge_dashboard.id}"
   description = "AWS EventBridge Dashboard URL"
 }

--- a/modules/eventbridge-dashboard/variables.tf
+++ b/modules/eventbridge-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/inspector-dashboard/main.tf
+++ b/modules/inspector-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_inspector_dashboard" {
-  project_name   = var.cloud_observability_project
+  project_name   = var.lightstep_project
   dashboard_name = "AWS Inspector"
 
   chart {

--- a/modules/inspector-dashboard/outputs.tf
+++ b/modules/inspector-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_inspector_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_inspector_dashboard.id}"
   description = "INSPECTOR Dashboard URL"
 }

--- a/modules/inspector-dashboard/variables.tf
+++ b/modules/inspector-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/kinesis-dashboard/main.tf
+++ b/modules/kinesis-dashboard/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 
 resource "lightstep_dashboard" "aws_kinesis_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS Kinesis"
   dashboard_description = ""
 

--- a/modules/kinesis-dashboard/outputs.tf
+++ b/modules/kinesis-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_kinesis_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_kinesis_dashboard.id}"
   description = "Kinesis Dashboard URL"
 }

--- a/modules/kinesis-dashboard/variables.tf
+++ b/modules/kinesis-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/lambda-dashboard/main.tf
+++ b/modules/lambda-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_lambda_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS Lambda"
   dashboard_description = "Monitor AWS Lambda with this summary dashboard."
 

--- a/modules/lambda-dashboard/outputs.tf
+++ b/modules/lambda-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_lambda_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_lambda_dashboard.id}"
   description = "Lambda Dashboard URL"
 }

--- a/modules/lambda-dashboard/variables.tf
+++ b/modules/lambda-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/msk-dashboard/main.tf
+++ b/modules/msk-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_msk_dashboard" {
-  project_name   = var.cloud_observability_project
+  project_name   = var.lightstep_project
   dashboard_name = "AWS MSK"
 
   chart {

--- a/modules/msk-dashboard/outputs.tf
+++ b/modules/msk-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_msk_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_msk_dashboard.id}"
   description = "MSK Dashboard URL"
 }

--- a/modules/msk-dashboard/variables.tf
+++ b/modules/msk-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/msk-topic-dashboard/main.tf
+++ b/modules/msk-topic-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_mks_topic_dashboard" {
-  project_name   = var.cloud_observability_project
+  project_name   = var.lightstep_project
   dashboard_name = "AWS Kafka Topic"
 
   chart {

--- a/modules/msk-topic-dashboard/outputs.tf
+++ b/modules/msk-topic-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_mks_topic_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_mks_topic_dashboard.id}"
   description = "MSK Topic Dashboard URL"
 }

--- a/modules/msk-topic-dashboard/variables.tf
+++ b/modules/msk-topic-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/natgateway-dashboard/main.tf
+++ b/modules/natgateway-dashboard/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 
 resource "lightstep_dashboard" "aws_natgateway_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS NAT Gateway"
   dashboard_description = "Monitor AWS NAT Gateway with this summary dashboard."
 

--- a/modules/natgateway-dashboard/outputs.tf
+++ b/modules/natgateway-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_natgateway_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_natgateway_dashboard.id}"
   description = "NATGateway Dashboard URL"
 }

--- a/modules/natgateway-dashboard/variables.tf
+++ b/modules/natgateway-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/networkfirewall-dashboard/main.tf
+++ b/modules/networkfirewall-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_networkfirewall_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS Network Firewall"
   dashboard_description = "Monitor AWS Network Firewall with this dashboard."
 

--- a/modules/networkfirewall-dashboard/outputs.tf
+++ b/modules/networkfirewall-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_networkfirewall_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_networkfirewall_dashboard.id}"
   description = "Network Firewall Dashboard URL"
 }

--- a/modules/networkfirewall-dashboard/variables.tf
+++ b/modules/networkfirewall-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/rds-dashboard/main.tf
+++ b/modules/rds-dashboard/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 
 resource "lightstep_dashboard" "aws_rds_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS RDS"
   dashboard_description = "Monitor AWS  RDS that collects and processes raw data"
 

--- a/modules/rds-dashboard/outputs.tf
+++ b/modules/rds-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_rds_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_rds_dashboard.id}"
   description = "RDS Dashboard URL"
 }

--- a/modules/rds-dashboard/variables.tf
+++ b/modules/rds-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/redshift-dashboard/main.tf
+++ b/modules/redshift-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_redshift_dashboard" {
-  project_name   = var.cloud_observability_project
+  project_name   = var.lightstep_project
   dashboard_name = "AWS Redshift"
 
   chart {

--- a/modules/redshift-dashboard/outputs.tf
+++ b/modules/redshift-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_redshift_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_redshift_dashboard.id}"
   description = "REDSHIFT Dashboard URL"
 }

--- a/modules/redshift-dashboard/variables.tf
+++ b/modules/redshift-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/route53-dashboard/main.tf
+++ b/modules/route53-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_route53_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS Route53"
   dashboard_description = "Monitor AWS Route53 with this summary dashboard."
 

--- a/modules/route53-dashboard/outputs.tf
+++ b/modules/route53-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_route53_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_route53_dashboard.id}"
   description = "ROUTE53 Dashboard URL"
 }

--- a/modules/route53-dashboard/variables.tf
+++ b/modules/route53-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/s3-dashboard/main.tf
+++ b/modules/s3-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_s3_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS S3"
   dashboard_description = "Monitor AWS S3 performance with this overview dashboard."
 

--- a/modules/s3-dashboard/outputs.tf
+++ b/modules/s3-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_s3_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_s3_dashboard.id}"
   description = "SNS Dashboard URL"
 }

--- a/modules/s3-dashboard/variables.tf
+++ b/modules/s3-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/ses-dashboard/main.tf
+++ b/modules/ses-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_ses_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS SES"
   dashboard_description = "Monitor AWS SES with this dashboard."
 

--- a/modules/ses-dashboard/outputs.tf
+++ b/modules/ses-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_ses_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_ses_dashboard.id}"
   description = "Simple Email Service Dashboard URL"
 }

--- a/modules/ses-dashboard/variables.tf
+++ b/modules/ses-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/sns-dashboard/main.tf
+++ b/modules/sns-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_sns_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS SNS"
   dashboard_description = "Monitor AWS SNS performance with this summary dashboard."
 

--- a/modules/sns-dashboard/outputs.tf
+++ b/modules/sns-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_sns_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_sns_dashboard.id}"
   description = "SNS Dashboard URL"
 }

--- a/modules/sns-dashboard/variables.tf
+++ b/modules/sns-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/sqs-dashboard/main.tf
+++ b/modules/sqs-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_sqs_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS SQS"
   dashboard_description = "Monitor AWS SQS with this summary dashboard."
 

--- a/modules/sqs-dashboard/outputs.tf
+++ b/modules/sqs-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_sqs_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_sqs_dashboard.id}"
   description = "SQS Dashboard URL"
 }

--- a/modules/sqs-dashboard/variables.tf
+++ b/modules/sqs-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/modules/stepfunctions-dashboard/main.tf
+++ b/modules/stepfunctions-dashboard/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "aws_step_functions_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "AWS Step Functions"
   dashboard_description = "Monitor AWS Step Functions with this view of execution results."
 

--- a/modules/stepfunctions-dashboard/outputs.tf
+++ b/modules/stepfunctions-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value       = "https://app.lightstep.com/${var.cloud_observability_project}/dashboard/${lightstep_dashboard.aws_step_functions_dashboard.id}"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_dashboard.aws_step_functions_dashboard.id}"
   description = "AWS Step Functions Dashboard URL"
 }

--- a/modules/stepfunctions-dashboard/variables.tf
+++ b/modules/stepfunctions-dashboard/variables.tf
@@ -1,4 +1,4 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,195 +1,195 @@
 
-output "cloud_observability_amplify_dashboard_url" {
-  value       = module.cloud_observability_amplify_dashboard.dashboard_url
+output "lightstep_amplify_dashboard_url" {
+  value       = module.lightstep_amplify_dashboard.dashboard_url
   description = "Cloud Observability AWS Amplify Dashboard"
 }
 
-output "cloud_observability_apigateway_dashboard_url" {
-  value       = module.cloud_observability_apigateway_dashboard.dashboard_url
+output "lightstep_apigateway_dashboard_url" {
+  value       = module.lightstep_apigateway_dashboard.dashboard_url
   description = "Cloud Observability AWS API Gateway Dashboard"
 }
 
-output "cloud_observability_applicationelb_dashboard_url" {
-  value       = module.cloud_observability_applicationelb_dashboard.dashboard_url
+output "lightstep_applicationelb_dashboard_url" {
+  value       = module.lightstep_applicationelb_dashboard.dashboard_url
   description = "Cloud Observability AWS Application ELB Dashboard"
 }
 
-output "cloud_observability_athena_dashboard_url" {
-  value       = module.cloud_observability_athena_dashboard.dashboard_url
+output "lightstep_athena_dashboard_url" {
+  value       = module.lightstep_athena_dashboard.dashboard_url
   description = "Cloud Observability AWS Athena Dashboard"
 }
 
-output "cloud_observability_aurora_dashboard_url" {
-  value       = module.cloud_observability_aurora_dashboard.dashboard_url
+output "lightstep_aurora_dashboard_url" {
+  value       = module.lightstep_aurora_dashboard.dashboard_url
   description = "Cloud Observability AWS Aurora Dashboard"
 }
 
-output "cloud_observability_autoscaling_dashboard_url" {
-  value       = module.cloud_observability_autoscaling_dashboard.dashboard_url
+output "lightstep_autoscaling_dashboard_url" {
+  value       = module.lightstep_autoscaling_dashboard.dashboard_url
   description = "Cloud Observability AWS AutoScaling Dashboard"
 }
 
-output "cloud_observability_backup_dashboard_url" {
-  value       = module.cloud_observability_backup_dashboard.dashboard_url
+output "lightstep_backup_dashboard_url" {
+  value       = module.lightstep_backup_dashboard.dashboard_url
   description = "Cloud Observability AWS Backup Dashboard"
 }
 
-output "cloud_observability_certificatemanager_dashboard_url" {
-  value       = module.cloud_observability_certificatemanager_dashboard.dashboard_url
+output "lightstep_certificatemanager_dashboard_url" {
+  value       = module.lightstep_certificatemanager_dashboard.dashboard_url
   description = "Cloud Observability AWS Certificate Manager Dashboard"
 }
 
-output "cloud_observability_chatbot_dashboard_url" {
-  value       = module.cloud_observability_chatbot_dashboard.dashboard_url
+output "lightstep_chatbot_dashboard_url" {
+  value       = module.lightstep_chatbot_dashboard.dashboard_url
   description = "Cloud Observability AWS Chatbot Dashboard"
 }
 
-output "cloud_observability_chime_dashboard_url" {
-  value       = module.cloud_observability_chime_dashboard.dashboard_url
+output "lightstep_chime_dashboard_url" {
+  value       = module.lightstep_chime_dashboard.dashboard_url
   description = "Cloud Observability AWS Chime SDK Dashboard"
 }
 
-output "cloud_observability_cloudfront_dashboard_url" {
-  value       = module.cloud_observability_cloudfront_dashboard.dashboard_url
+output "lightstep_cloudfront_dashboard_url" {
+  value       = module.lightstep_cloudfront_dashboard.dashboard_url
   description = "Cloud Observability AWS CloudFront Dashboard"
 }
 
-output "cloud_observability_cloudhsm_dashboard_url" {
-  value       = module.cloud_observability_cloudhsm_dashboard.dashboard_url
+output "lightstep_cloudhsm_dashboard_url" {
+  value       = module.lightstep_cloudhsm_dashboard.dashboard_url
   description = "Cloud Observability AWS CloudHSM Dashboard"
 }
 
-output "cloud_observability_cloudtrail_dashboard_url" {
-  value       = module.cloud_observability_cloudtrail_dashboard.dashboard_url
+output "lightstep_cloudtrail_dashboard_url" {
+  value       = module.lightstep_cloudtrail_dashboard.dashboard_url
   description = "Cloud Observability AWS CloudTrail Dashboard"
 }
 
-output "cloud_observability_cognito_dashboard_url" {
-  value       = module.cloud_observability_cognito_dashboard.dashboard_url
+output "lightstep_cognito_dashboard_url" {
+  value       = module.lightstep_cognito_dashboard.dashboard_url
   description = "Cloud Observability AWS Cognito Dashboard"
 }
 
-output "cloud_observability_dynamodb_dashboard_url" {
-  value       = module.cloud_observability_dynamodb_dashboard.dashboard_url
+output "lightstep_dynamodb_dashboard_url" {
+  value       = module.lightstep_dynamodb_dashboard.dashboard_url
   description = "Cloud Observability AWS DynamoDB Dashboard"
 }
 
-output "cloud_observability_ebs_dashboard_url" {
-  value       = module.cloud_observability_ebs_dashboard.dashboard_url
+output "lightstep_ebs_dashboard_url" {
+  value       = module.lightstep_ebs_dashboard.dashboard_url
   description = "Cloud Observability AWS EBS Dashboard"
 }
 
-output "cloud_observability_ec2_dashboard_url" {
-  value       = module.cloud_observability_ec2_dashboard.dashboard_url
+output "lightstep_ec2_dashboard_url" {
+  value       = module.lightstep_ec2_dashboard.dashboard_url
   description = "Cloud Observability AWS EC2 Dashboard"
 }
 
-output "cloud_observability_ecs_dashboard_url" {
-  value       = module.cloud_observability_ecs_dashboard.dashboard_url
+output "lightstep_ecs_dashboard_url" {
+  value       = module.lightstep_ecs_dashboard.dashboard_url
   description = "Cloud Observability AWS ECS Dashboard"
 }
 
-output "cloud_observability_efs_dashboard_url" {
-  value       = module.cloud_observability_efs_dashboard.dashboard_url
+output "lightstep_efs_dashboard_url" {
+  value       = module.lightstep_efs_dashboard.dashboard_url
   description = "Cloud Observability AWS EFS Dashboard"
 }
 
-output "cloud_observability_eks_node_dashboard_url" {
-  value       = module.cloud_observability_eks_node_dashboard.dashboard_url
+output "lightstep_eks_node_dashboard_url" {
+  value       = module.lightstep_eks_node_dashboard.dashboard_url
   description = "Cloud Observability AWS EKS Node Dashboard"
 }
 
-output "cloud_observability_eks_pod_dashboard_url" {
-  value       = module.cloud_observability_eks_pod_dashboard.dashboard_url
+output "lightstep_eks_pod_dashboard_url" {
+  value       = module.lightstep_eks_pod_dashboard.dashboard_url
   description = "Cloud Observability AWS EKS Pod Dashboard"
 }
 
-output "cloud_observability_elasticache_redis_dashboard_url" {
-  value       = module.cloud_observability_elasticache_redis_dashboard.dashboard_url
+output "lightstep_elasticache_redis_dashboard_url" {
+  value       = module.lightstep_elasticache_redis_dashboard.dashboard_url
   description = "Cloud Observability AWS ElastiCache (Redis) Dashboard"
 }
 
-output "cloud_observability_elasticmapreduce_dashboard_url" {
-  value       = module.cloud_observability_elasticmapreduce_dashboard.dashboard_url
+output "lightstep_elasticmapreduce_dashboard_url" {
+  value       = module.lightstep_elasticmapreduce_dashboard.dashboard_url
   description = "Cloud Observability AWS EMR Hadoop 2 Dashboard"
 }
 
-output "cloud_observability_eventbridge_dashboard_url" {
-  value       = module.cloud_observability_eventbridge_dashboard.dashboard_url
+output "lightstep_eventbridge_dashboard_url" {
+  value       = module.lightstep_eventbridge_dashboard.dashboard_url
   description = "Cloud Observability AWS EventBridge Dashboard"
 }
 
-output "cloud_observability_inspector_dashboard_url" {
-  value       = module.cloud_observability_inspector_dashboard.dashboard_url
+output "lightstep_inspector_dashboard_url" {
+  value       = module.lightstep_inspector_dashboard.dashboard_url
   description = "Cloud Observability AWS Inspector Dashboard"
 }
 
-output "cloud_observability_kinesis_dashboard_url" {
-  value       = module.cloud_observability_kinesis_dashboard.dashboard_url
+output "lightstep_kinesis_dashboard_url" {
+  value       = module.lightstep_kinesis_dashboard.dashboard_url
   description = "Cloud Observability AWS Kinesis Dashboard"
 }
 
-output "cloud_observability_lambda_dashboard_url" {
-  value       = module.cloud_observability_lambda_dashboard.dashboard_url
+output "lightstep_lambda_dashboard_url" {
+  value       = module.lightstep_lambda_dashboard.dashboard_url
   description = "Cloud Observability AWS Lambda Dashboard"
 }
 
-output "cloud_observability_msk_dashboard_url" {
-  value       = module.cloud_observability_msk_dashboard.dashboard_url
+output "lightstep_msk_dashboard_url" {
+  value       = module.lightstep_msk_dashboard.dashboard_url
   description = "Cloud Observability AWS MSK Dashboard"
 }
 
-output "cloud_observability_msk_topic_dashboard_url" {
-  value       = module.cloud_observability_msk_topic_dashboard.dashboard_url
+output "lightstep_msk_topic_dashboard_url" {
+  value       = module.lightstep_msk_topic_dashboard.dashboard_url
   description = "Cloud Observability AWS Kafka Topic Dashboard"
 }
 
-output "cloud_observability_natgateway_dashboard_url" {
-  value       = module.cloud_observability_natgateway_dashboard.dashboard_url
+output "lightstep_natgateway_dashboard_url" {
+  value       = module.lightstep_natgateway_dashboard.dashboard_url
   description = "Cloud Observability AWS NAT Gateway Dashboard"
 }
 
-output "cloud_observability_networkfirewall_dashboard_url" {
-  value       = module.cloud_observability_networkfirewall_dashboard.dashboard_url
+output "lightstep_networkfirewall_dashboard_url" {
+  value       = module.lightstep_networkfirewall_dashboard.dashboard_url
   description = "Cloud Observability AWS Network Firewall Dashboard"
 }
 
-output "cloud_observability_rds_dashboard_url" {
-  value       = module.cloud_observability_rds_dashboard.dashboard_url
+output "lightstep_rds_dashboard_url" {
+  value       = module.lightstep_rds_dashboard.dashboard_url
   description = "Cloud Observability AWS RDS Dashboard"
 }
 
-output "cloud_observability_redshift_dashboard_url" {
-  value       = module.cloud_observability_redshift_dashboard.dashboard_url
+output "lightstep_redshift_dashboard_url" {
+  value       = module.lightstep_redshift_dashboard.dashboard_url
   description = "Cloud Observability AWS Redshift Dashboard"
 }
 
-output "cloud_observability_route53_dashboard_url" {
-  value       = module.cloud_observability_route53_dashboard.dashboard_url
+output "lightstep_route53_dashboard_url" {
+  value       = module.lightstep_route53_dashboard.dashboard_url
   description = "Cloud Observability AWS Route53 Dashboard"
 }
 
-output "cloud_observability_s3_dashboard_url" {
-  value       = module.cloud_observability_s3_dashboard.dashboard_url
+output "lightstep_s3_dashboard_url" {
+  value       = module.lightstep_s3_dashboard.dashboard_url
   description = "Cloud Observability AWS S3 Dashboard"
 }
 
-output "cloud_observability_ses_dashboard_url" {
-  value       = module.cloud_observability_ses_dashboard.dashboard_url
+output "lightstep_ses_dashboard_url" {
+  value       = module.lightstep_ses_dashboard.dashboard_url
   description = "Cloud Observability AWS SES Dashboard"
 }
 
-output "cloud_observability_sns_dashboard_url" {
-  value       = module.cloud_observability_sns_dashboard.dashboard_url
+output "lightstep_sns_dashboard_url" {
+  value       = module.lightstep_sns_dashboard.dashboard_url
   description = "Cloud Observability AWS SNS Dashboard"
 }
 
-output "cloud_observability_sqs_dashboard_url" {
-  value       = module.cloud_observability_sqs_dashboard.dashboard_url
+output "lightstep_sqs_dashboard_url" {
+  value       = module.lightstep_sqs_dashboard.dashboard_url
   description = "Cloud Observability AWS SQS Dashboard"
 }
 
-output "cloud_observability_stepfunctions_dashboard_url" {
-  value       = module.cloud_observability_stepfunctions_dashboard.dashboard_url
+output "lightstep_stepfunctions_dashboard_url" {
+  value       = module.lightstep_stepfunctions_dashboard.dashboard_url
   description = "Cloud Observability AWS Step Functions Dashboard"
 }

--- a/tools/bump
+++ b/tools/bump
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# get latest version of lightstep provider
+LATEST_VERSION=$(curl -s "https://registry.terraform.io/v1/providers/lightstep/lightstep/versions" | jq -r '.versions[] | select(.version) | .version' | sort -V | tail -1)
+
+echo "Latest provider version is $LATEST_VERSION"
+
+# safer to target file types with the -name flag like .. -name "*.tf", but I at least
+# need this to apply
+find . -type f \( -name "*.go" -name "*.tf" \) -exec sed -i '' -E "s/version = \"~> ([0-9]+\.){2}[0-9]+\"/version = \"~> $LATEST_VERSION\"/g" {} +

--- a/tools/generaterootmod.go
+++ b/tools/generaterootmod.go
@@ -24,9 +24,9 @@ func writeMainHead(w io.Writer) {
 }
 
 provider "lightstep" {
-  api_key_env_var = var.cloud_observability_api_key_env_var
-  organization    = var.cloud_observability_organization
-  environment     = var.cloud_observability_env
+  api_key_env_var = var.lightstep_api_key_env_var
+  organization    = var.lightstep_organization
+  environment     = var.lightstep_env
 }
 `)
 }
@@ -40,9 +40,9 @@ func writeMainModuleBlocks(w io.Writer, dirPath string) error {
 	for _, file := range files {
 		if file.IsDir() {
 			dirSnake := strings.ReplaceAll(file.Name(), "-", "_")
-			fmt.Fprintf(w, "\nmodule \"cloud_observability_%s\" {\n", dirSnake)
+			fmt.Fprintf(w, "\nmodule \"lightstep_%s\" {\n", dirSnake)
 			fmt.Fprintf(w, "  source            = \"./modules/%s\"\n", file.Name())
-			fmt.Fprint(w, "  cloud_observability_project = var.cloud_observability_project\n")
+			fmt.Fprint(w, "  lightstep_project = var.lightstep_project\n")
 			fmt.Fprint(w, "}\n")
 		}
 	}
@@ -91,8 +91,8 @@ func writeOutputsBlocks(w io.Writer, dirPath string) error {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(w, "\noutput \"cloud_observability_%s_url\" {\n", dirSnake)
-			fmt.Fprintf(w, "  value       = module.cloud_observability_%s.dashboard_url\n", dirSnake)
+			fmt.Fprintf(w, "\noutput \"lightstep_%s_url\" {\n", dirSnake)
+			fmt.Fprintf(w, "  value       = module.lightstep_%s.dashboard_url\n", dirSnake)
 			fmt.Fprintf(w, "  description = \"Cloud Observability AWS %s Dashboard\"\n", appName)
 			fmt.Fprint(w, "}\n")
 		}

--- a/variables.tf
+++ b/variables.tf
@@ -1,20 +1,20 @@
-variable "cloud_observability_project" {
+variable "lightstep_project" {
   description = "Name of Cloud Observability project"
   type        = string
 }
 
-variable "cloud_observability_organization" {
+variable "lightstep_organization" {
   description = "Name of Cloud Observability organization"
   type        = string
 }
 
-variable "cloud_observability_env" {
+variable "lightstep_env" {
   description = "Cloud Observability environment"
   type        = string
   default     = "public"
 }
 
-variable "cloud_observability_api_key_env_var" {
+variable "lightstep_api_key_env_var" {
   description = "Name of the local environment variable that contains the Cloud Observability API key"
   type        = string
   default     = "LIGHTSTEP_API_KEY"


### PR DESCRIPTION
The purpose of this PR was to revert some remaining cases of `cloud_observability_` prefixed variables to the `lightstep_` prefix. Additionally we applied some `terraform fmt` changes that were needed for CI in this repo.

The changes to the variable prefixes are consistent with how the rebranding was intended. The new variable names were applied in error as an extension from rebranding in non-code and non-configuration portions.