### PR TITLE
LS-57918 setup dependabot.yml to automatically update the provider version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'terraform' # See documentation for possible values
+    directory: '/modules' # Location of package manifests
+    schedule:
+      interval: 'daily'
+  - package-ecosystem: 'terraform' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    schedule:
+      interval: 'daily'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/enterprise-cloud@latest/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:


### PR DESCRIPTION
Today, the process of updating provider versions is very manual. This PR configures dependabot for this repo so that when a new provider version is released, dependabot will submit a PR updating these dependencies. It will check for updates daily.

I forked this repo and tried it out here: https://github.com/adil-sultan/terraform-lightstep-aws-dashboards/pull/2

Before merging this PR I need the assistance of an admin to configure the security settings of the repo, steps here: https://docs.github.com/en/enterprise-cloud@latest/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-version-updates-on-forks